### PR TITLE
github action reproduce the bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,7 @@ jobs:
         cmake -G"Ninja Multi-Config" -B build . ;
         cmake --build build --config debug;
         echo Changing Cmake file
-        echo "##" >> CMakeLists.txt
-        
+        echo "This is should not build" >> CMakeLists.txt
         cmake --build build --config debug
         
         cmake --build build


### PR DESCRIPTION
after running ``` echo "This is should not build" >> CMakeLists.txt ```
the build should fail however
upon running ```cmake --build build --config debug```
it doesn't fail and echos "ninja: No work to do"
then running 
```cmake --build build ```
fails as expected
